### PR TITLE
Feature: Exclude search terms

### DIFF
--- a/common_scrapers.py
+++ b/common_scrapers.py
@@ -12,6 +12,12 @@ class GreenhousePage:
         job_elements = driver.find_elements(By.CLASS_NAME, "job-post")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -30,6 +36,12 @@ class GreenhouseEmbeddedStandalonePage:
         job_elements = driver.find_elements(By.CLASS_NAME, "opening")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -58,6 +70,12 @@ class LeverCoPage:
         job_elements = driver.find_elements(By.CLASS_NAME, "posting")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -77,6 +95,12 @@ class BambooPage:
         )
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             jobs.append(
                 JobPosting(
                     title=job.text,
@@ -93,11 +117,18 @@ class WorkablePage:
         job_elements = container.find_elements(By.XPATH, '//li[@data-ui="job"]')
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
                     title=job.text,
                     id=link_url,
+                    link=link_url
                 )
             )
         return jobs
@@ -170,6 +201,12 @@ class WorkdayPage:
                 if (
                     "title" in job
                 ):  # there are inconsistently sometimes entries that have no title or externalPath, just the bulletFields field
+                    if config and "exclude_search_terms" in config:
+                        lower_title = job["title"].lower()
+                        if any(
+                            term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                        ):
+                            continue
                     link_url = driver.current_url.split("?")[0] + job["externalPath"]
                     jobs.append(
                         JobPosting(
@@ -192,6 +229,12 @@ class RipplingPage:
         ]
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -214,6 +257,12 @@ class AshbyPage:
         for container in containers:
             job_elements = container.find_elements(By.TAG_NAME, "a")
             for job in job_elements:
+                if config and "exclude_search_terms" in config:
+                    lower_title = job.text.lower()
+                    if any(
+                        term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                    ):
+                        continue
                 link_url = job.get_attribute("href")
                 jobs.append(
                     JobPosting(
@@ -233,7 +282,7 @@ class AshbyEmbeddedPage:
         assert ashby_iframe.tag_name == "iframe"
         driver.switch_to.frame(ashby_iframe)
 
-        return AshbyPage.get_jobs(driver)
+        return AshbyPage.get_jobs(driver, config)
 
 
 class ApplyToJobPage:
@@ -243,6 +292,12 @@ class ApplyToJobPage:
         job_elements = container.find_elements(By.CSS_SELECTOR, "li.list-group-item")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -261,6 +316,12 @@ class SmartRecruitersPage:
         job_elements = container.find_elements(By.CSS_SELECTOR, "li.opening-job")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
@@ -318,6 +379,12 @@ class BitsInBioPage:
         job_elements = container.find_elements(By.CLASS_NAME, "job-item")
         jobs = []
         for job in job_elements:
+            if config and "exclude_search_terms" in config:
+                lower_title = job.text.lower()
+                if any(
+                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
+                ):
+                    continue
             button_row = job.find_element(By.CLASS_NAME, "faq-answer").find_element(
                 By.CLASS_NAME, "button-row"
             )

--- a/common_scrapers.py
+++ b/common_scrapers.py
@@ -1,8 +1,19 @@
+import re
 import requests
 import json
 from models import *
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
+
+
+def is_excluded(config, title) -> bool:
+    if config and "exclude_search_terms" in config:
+        lower_title = title.lower()
+        exclude_terms = [excluded_word.lower() for excluded_word in config["exclude_search_terms"]]
+        pattern = r'\b(?:' + '|'.join(re.escape(term) for term in exclude_terms) + r')\b'
+        if re.search(pattern, lower_title):
+            return True
+    return False
 
 
 # https://job-boards.greenhouse.io/company
@@ -12,16 +23,13 @@ class GreenhousePage:
         job_elements = driver.find_elements(By.CLASS_NAME, "job-post")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -36,16 +44,13 @@ class GreenhouseEmbeddedStandalonePage:
         job_elements = driver.find_elements(By.CLASS_NAME, "opening")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -70,16 +75,13 @@ class LeverCoPage:
         job_elements = driver.find_elements(By.CLASS_NAME, "posting")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -95,15 +97,12 @@ class BambooPage:
         )
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=job.find_element(By.TAG_NAME, "a").get_attribute("href"),
                 )
             )
@@ -117,16 +116,13 @@ class WorkablePage:
         job_elements = container.find_elements(By.XPATH, '//li[@data-ui="job"]')
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url
                 )
@@ -201,16 +197,13 @@ class WorkdayPage:
                 if (
                     "title" in job
                 ):  # there are inconsistently sometimes entries that have no title or externalPath, just the bulletFields field
-                    if config and "exclude_search_terms" in config:
-                        lower_title = job["title"].lower()
-                        if any(
-                            term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                        ):
-                            continue
+                    title = job["title"]
+                    if is_excluded(config, title):
+                        continue
                     link_url = driver.current_url.split("?")[0] + job["externalPath"]
                     jobs.append(
                         JobPosting(
-                            title=job["title"],
+                            title=title,
                             id=link_url,
                             link=link_url,
                         )
@@ -229,16 +222,13 @@ class RipplingPage:
         ]
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text
+                    title=title
                     + " (note this only shows one location but there might be multiple for this same link)",
                     id=link_url,
                     link=link_url,
@@ -257,16 +247,13 @@ class AshbyPage:
         for container in containers:
             job_elements = container.find_elements(By.TAG_NAME, "a")
             for job in job_elements:
-                if config and "exclude_search_terms" in config:
-                    lower_title = job.text.lower()
-                    if any(
-                        term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                    ):
-                        continue
+                title = job.text
+                if is_excluded(config, title):
+                    continue
                 link_url = job.get_attribute("href")
                 jobs.append(
                     JobPosting(
-                        title=job.text,
+                        title=title,
                         id=link_url,
                         link=link_url,
                     )
@@ -292,16 +279,13 @@ class ApplyToJobPage:
         job_elements = container.find_elements(By.CSS_SELECTOR, "li.list-group-item")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -316,16 +300,13 @@ class SmartRecruitersPage:
         job_elements = container.find_elements(By.CSS_SELECTOR, "li.opening-job")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             link_url = job.find_element(By.TAG_NAME, "a").get_attribute("href")
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -379,12 +360,9 @@ class BitsInBioPage:
         job_elements = container.find_elements(By.CLASS_NAME, "job-item")
         jobs = []
         for job in job_elements:
-            if config and "exclude_search_terms" in config:
-                lower_title = job.text.lower()
-                if any(
-                    term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
-                ):
-                    continue
+            title = job.text
+            if is_excluded(config, title):
+                continue
             button_row = job.find_element(By.CLASS_NAME, "faq-answer").find_element(
                 By.CLASS_NAME, "button-row"
             )
@@ -407,7 +385,7 @@ class BitsInBioPage:
 
             jobs.append(
                 JobPosting(
-                    title=job.text,
+                    title=title,
                     id=link_url,
                     link=link_url,
                 )
@@ -495,16 +473,10 @@ class ClimateTechListPage(JobsPage):
         time_cutoff = today - delta
 
         def has_relevant_title(row):
-            if config and "exclude_search_terms" in config:
-                lower_title = row["cellValuesByColumnId"][
-                    relevant_column_ids["Position Title"]
-                ].lower()
-                if any(
-                    term in lower_title for term in set(config["exclude_search_terms"])
-                ):
-                    return False
-
-            return True
+            title = row["cellValuesByColumnId"][
+                relevant_column_ids["Position Title"]
+            ]
+            return not is_excluded(config, title)
 
         def has_relevant_location(row):
             # Assumes capitalization

--- a/common_scrapers.py
+++ b/common_scrapers.py
@@ -8,10 +8,9 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 def is_excluded(config, title) -> bool:
     if config and "exclude_search_terms" in config:
-        lower_title = title.lower()
-        exclude_terms = [excluded_word.lower() for excluded_word in config["exclude_search_terms"]]
-        pattern = r'\b(?:' + '|'.join(re.escape(term) for term in exclude_terms) + r')\b'
-        if re.search(pattern, lower_title):
+        lower_title_words = set(title.lower().split())
+        exclude_terms = {excluded_word.lower() for excluded_word in config["exclude_search_terms"]}
+        if len(lower_title_words.intersection(exclude_terms)) > 0:
             return True
     return False
 

--- a/example_files/config.json
+++ b/example_files/config.json
@@ -33,5 +33,8 @@
 			"referral": "",
 			"application_history": ""
 		}
-	]
+	],
+	"default_config": {
+		"exclude_search_terms": [ "intern", "(m/f/d)", "(f/m/d)", "(m/w/d)", "QA", "Senior", "Sr.", "Sr", "Lead", "Deployed", "Principal", "Founding", "Servicenow", "splunk"]
+	}
 }

--- a/example_files/config.json
+++ b/example_files/config.json
@@ -35,6 +35,6 @@
 		}
 	],
 	"default_config": {
-		"exclude_search_terms": [ "intern", "(m/f/d)", "(f/m/d)", "(m/w/d)", "QA", "Senior", "Sr.", "Sr", "Lead", "Deployed", "Principal", "Founding", "Servicenow", "splunk"]
+		"exclude_search_terms": [ "intern", "(m/f/d)", "(f/m/d)", "(m/w/d)"]
 	}
 }

--- a/job_scrape.py
+++ b/job_scrape.py
@@ -249,7 +249,9 @@ def import_from_path(module_name, file_path):
     return module
 
 
-def get_companies(config_companies, additional_scrapers_module=None):
+def get_companies(
+    config_companies, default_config=None, additional_scrapers_module=None
+):
     import common_scrapers
     import inspect
 
@@ -264,6 +266,8 @@ def get_companies(config_companies, additional_scrapers_module=None):
 
     companies = []
     for company in config_companies:
+        if "config" not in company:
+            company["config"] = default_config
         company["jobs_page_class"] = all_scrapers[company["jobs_page_class_name"]]
         companies.append(Company(**company))
     return companies
@@ -338,7 +342,12 @@ if __name__ == "__main__":
     if args.config_file.endswith(".json"):
         with open(args.config_file) as f:
             config = json.load(f)
-            companies = get_companies(config["companies"], additional_scrapers_module)
+            default_config = (
+                config["default_config"] if "default_config" in config else None
+            )
+            companies = get_companies(
+                config["companies"], default_config, additional_scrapers_module
+            )
             search_terms = config["search_terms"]
     else:
         config_module = import_from_path("config", args.config_file)


### PR DESCRIPTION
# Exclude search terms and default configurations

## Exclude search terms

Most of the classes includes this to implement excludes
```python
...
if config and "exclude_search_terms" in config:
    lower_title = job.text.lower()
    if any(
        term in lower_title for term in set([excluded_word.lower() for excluded_word in config["exclude_search_terms"]])
    ):
        continue
...
```


## Default Config
Added a default_config which takes the same parameters as config. At the moment only exclude_search_terms is used.
a company config will override the default config, so you can set a single default and disable / customize it for a company by adding config to that company. 

```python
if "config" not in company:
    company["config"] = default_config
```

```json
{
	"search_terms": ["software", "developer", "engineer"],
	"companies": [
		{
			"name": "Athena Health",
			... // Will use default_config by default
		},
		{
			"name": "Capital One",
			...,
			"config": {} // Disables default config options in Capital one
		},
	],
	"default_config": {
		"exclude_search_terms": [ "intern", "(m/f/d)", "(f/m/d)", "(m/w/d)", "President"],
		...
	}
}
```

### Affected Classes

This PR implements the exclude search terms for various scraper classes
- [x] GreenhousePage
- [x] GreenhouseEmbededStandalonePage
- [x] LeverCoPage
- [x] BambooPage
- [x] WorkablePage
- [x] WorkdayPage
- [x] RipplingPAge
- [x] AshbyPage
- [x] ApplyToJobPage
- [x] SmartRecruitersPage
- [x] BitsInBioPage