### PR TITLE
Implement default company config

### DIFF
--- a/example_files/config.json
+++ b/example_files/config.json
@@ -33,5 +33,8 @@
 			"referral": "",
 			"application_history": ""
 		}
-	]
+	],
+	"default_config": {
+		"exclude_search_terms": [ "intern", "(m/f/d)", "(f/m/d)", "(m/w/d)"]
+	}
 }

--- a/job_scrape.py
+++ b/job_scrape.py
@@ -249,7 +249,9 @@ def import_from_path(module_name, file_path):
     return module
 
 
-def get_companies(config_companies, additional_scrapers_module=None):
+def get_companies(
+    config_companies, default_config=None, additional_scrapers_module=None
+):
     import common_scrapers
     import inspect
 
@@ -264,6 +266,8 @@ def get_companies(config_companies, additional_scrapers_module=None):
 
     companies = []
     for company in config_companies:
+        if "config" not in company:
+            company["config"] = default_config
         company["jobs_page_class"] = all_scrapers[company["jobs_page_class_name"]]
         companies.append(Company(**company))
     return companies
@@ -338,7 +342,12 @@ if __name__ == "__main__":
     if args.config_file.endswith(".json"):
         with open(args.config_file) as f:
             config = json.load(f)
-            companies = get_companies(config["companies"], additional_scrapers_module)
+            default_config = (
+                config["default_config"] if "default_config" in config else None
+            )
+            companies = get_companies(
+                config["companies"], default_config, additional_scrapers_module
+            )
             search_terms = config["search_terms"]
     else:
         config_module = import_from_path("config", args.config_file)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -99,6 +99,11 @@ def lambda_handler(event, context, local=False):
             config = json.loads(config_file_content)
             companies = get_companies(config["companies"], additional_scrapers_module)
             search_terms = config["search_terms"]
+            default_company_config = (
+                config["default_company_config"]
+                if "default_company_config" in config
+                else None
+            )
         else:
             assert "config_file" in event["aws_config"]
             config_path = os.path.join(tmp_config_scrapers_folder, "config.py")
@@ -112,6 +117,11 @@ def lambda_handler(event, context, local=False):
                 for company in config_module.get_companies(additional_scrapers_module)
             ]
             search_terms = config_module.search_terms
+            default_company_config = (
+                config_module.default_company_config
+                if hasattr(config_module, "default_company_config")
+                else None
+            )
 
     run_record_object = s3.Object(
         event["aws_config"]["bucket_name"], event["aws_config"]["run_record_json"]
@@ -125,6 +135,7 @@ def lambda_handler(event, context, local=False):
             run_record,
             companies,
             search_terms,
+            default_company_config,
             limit_company,
             temp_term,
             default_sleep,


### PR DESCRIPTION
Hey @Jesulayomy !

tl;dr
- Don't feel bad about the code you wrote! I approved the PR, have no tests, and this is a bunch of duct tape anyway just to get something working
- Switch the key in your `config.json` from `default_config` to `default_company_config`, and your default should work after this deploys. Let me know if it doesn't!

So the issue is that there are effectively 4 entrypoints to the scrape
1. Running job_scrape.py directly locally, when the config file is a json
2. Running job_scrape.py directly locally, when the config file is a python file (for my/the infrastructure host's personal use of having comments)
3. Running lambda_function.py (which is what runs on the AWS infra), when the config file is a json
4. Running lambda_function.py, when the config file is a python file

The bug was caused because the prior implementation of "default config" only implemented it for entrypoint 1. The second and third args of the `get_companies` function default to None, so `get_companies` didn't throw an error when called, but instead the third `additional_scrapers_module` args was getting passed as if it were the `default_config`. Resulting in the error that a module (the `additional_scrapers_module`) is not iterable.

I've implemented all 4 entrypoints. Additionally,
1. I'm implementing the name for this as `default_company_config` and not `default_config`, because the file itself is a `config.json`. And I wanted to be clear this was the per-company config, not a default for the entire file.
2. Since this is a global default, I felt that is made more sense to pass the default into `get_new_relevant_jobs` similar to how the search terms are, instead of populating the same copy into every company that doesn't specify its own config.

If you're interested specifically in the changes I made on top of you initial PR, see the second commit.